### PR TITLE
Fixes - Push to any branch, not just master and two simple rubocop failures

### DIFF
--- a/lib/horatio.rb
+++ b/lib/horatio.rb
@@ -49,7 +49,7 @@ def run_sh(cmd)
     color { Log.info "executing command: #{cmd}" }
     o, e, s = sh(cmd)
 
-    if s.exitstatus == 0
+    if s.exitstatus.zero?
       color { Log.info "succesfully executed command `#{cmd}` output:\n #{o}" }
     else
       raise "execution of `#{cmd}` failed output from STDERR was:\n #{e}\n STDOUT was:\n #{o}"

--- a/lib/horatio/vcs/git.rb
+++ b/lib/horatio/vcs/git.rb
@@ -14,7 +14,7 @@ module Horatio
       def latest_revision
         sh('git rev-parse --short HEAD').first.strip
       end
-      
+   
       def current_branch
         sh('git rev-parse --abbrev-ref HEAD').strip
       end

--- a/lib/horatio/vcs/git.rb
+++ b/lib/horatio/vcs/git.rb
@@ -20,7 +20,7 @@ module Horatio
           sh "git remote rm horatio &> /dev/null"
           run_sh "git remote add horatio #{remote_url}"
           run_sh "git commit -m 'image release' #{file}"
-          run_sh "git push horatio master"
+	  run_sh "git push horatio `git branch | grep \* | cut -d ' ' -f2`"
       end
 
       def remote_url

--- a/lib/horatio/vcs/git.rb
+++ b/lib/horatio/vcs/git.rb
@@ -14,13 +14,17 @@ module Horatio
       def latest_revision
         sh('git rev-parse --short HEAD').first.strip
       end
+      
+      def current_branch
+        sh('git rev-parse --abbrev-ref HEAD').strip
+      end
 
       def commit(file)
           color { Log.info "Adding remote before pushing verion update: #{remote_url}" }
           sh "git remote rm horatio &> /dev/null"
           run_sh "git remote add horatio #{remote_url}"
           run_sh "git commit -m 'image release' #{file}"
-          run_sh "git push horatio `git branch | grep \* | cut -d ' ' -f2`"
+          run_sh "git push horatio #{current_branch}"
       end
 
       def remote_url

--- a/lib/horatio/vcs/git.rb
+++ b/lib/horatio/vcs/git.rb
@@ -8,7 +8,7 @@ module Horatio
       include Horatio::Helper::VCS
 
       def self.detect
-        sh('git rev-parse HEAD').last.exitstatus == 0
+        sh('git rev-parse HEAD').last.exitstatus.zero?
       end
 
       def latest_revision
@@ -20,7 +20,7 @@ module Horatio
           sh "git remote rm horatio &> /dev/null"
           run_sh "git remote add horatio #{remote_url}"
           run_sh "git commit -m 'image release' #{file}"
-	  run_sh "git push horatio `git branch | grep \* | cut -d ' ' -f2`"
+          run_sh "git push horatio `git branch | grep \* | cut -d ' ' -f2`"
       end
 
       def remote_url


### PR DESCRIPTION
This is a simple fix to push the `horatio.json` to the current branch, not just master.
